### PR TITLE
Added support for referenceValue and geoPointValue to FirestoreFieldValue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "jose": "^4.14.4"
+        "jose": "^4.14.4",
+        "urlpattern-polyfill": "^10.1.0"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
@@ -8010,6 +8011,12 @@
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+      "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "jose": "^4.14.4"
+    "jose": "^4.14.4",
+    "urlpattern-polyfill": "^10.1.0"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,8 +12,27 @@ export interface FirestoreConfig {
   emulatorPort?: number;
 }
 
+// A reference to a document. For example: `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+export type FirestoreLiteralDocumentReference = { referenceValue: string }
+/**
+ * A geo point value representing a point on the surface of Earth.
+ */
+export type FirestoreLiteralGeoPointValue = {
+  geoPointValue: {
+    /**
+     * The latitude in degrees. It must be in the range [-90.0, +90.0].
+     */
+    latitude: number,
+    /**
+     * The longitude in degrees. It must be in the range [-180.0, +180.0].
+     */
+    longitude: number
+  } 
+};
+
 /**
  * Firestoreの値型定義
+ * See: https://github.com/googleapis/google-api-nodejs-client/blob/5870dfe31f4885eebc82c19f7471c50403308f26/src/apis/firestore/v1.ts#L2246
  */
 export type FirestoreFieldValue =
   | { stringValue: string }
@@ -22,6 +41,8 @@ export type FirestoreFieldValue =
   | { booleanValue: boolean }
   | { nullValue: null }
   | { timestampValue: string }
+  | FirestoreLiteralGeoPointValue
+  | FirestoreLiteralDocumentReference
   | { mapValue: { fields: Record<string, FirestoreFieldValue> } }
   | { arrayValue: { values: FirestoreFieldValue[] } };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { URLPattern } from "urlpattern-polyfill"
+
 /**
  * Firestoreクライアントの設定インターフェース
  */
@@ -12,12 +14,89 @@ export interface FirestoreConfig {
   emulatorPort?: number;
 }
 
-// A reference to a document. For example: `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
-export type FirestoreLiteralDocumentReference = { referenceValue: string }
+/**
+ * A reference to a document. For example: `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+ * Used to represent document references globally and not connected to any particular client.
+ */
+export class LiteralDocumentReference {
+  referenceValue: string;
+  constructor(options: Pick<LiteralDocumentReference, "referenceValue">) {
+    this.referenceValue = options.referenceValue;
+  }
+
+  /**
+   * The pattern for globally unique Firestore Document Reference paths
+   */
+  private static pattern = new URLPattern({ pathname: `/projects/:project_id/databases/:database_id/documents/:document_path*`});
+
+  /**
+   * Parse using URLPattern, which is a relatively new addition to the standard.
+   * See: https://urlpattern.spec.whatwg.org/#dom-urlpattern-protocol
+   * Added in Node.js v23: https://nodejs.org/api/url.html#class-urlpattern
+   * Baseline 2025 in browsers: https://developer.mozilla.org/en-US/docs/Web/API/URLPattern/protocol
+   * @returns 
+   */
+  private parse() {
+    const result = LiteralDocumentReference.pattern.exec(`https://hostname/${this.referenceValue}`);
+    if (!result) throw new Error("Invalid document path. Path does not match pattern.");
+
+    const project_id = result.pathname.groups["project_id"];
+    if (!project_id) throw new Error("Invalid document path. Path does not match pattern.");
+    const database_id = result.pathname.groups["database_id"];
+    if (!database_id) throw new Error("Invalid document path. Path does not match pattern.");
+    const document_path = result.pathname.groups["document_path"];
+    if (!document_path) throw new Error("Invalid document path. Path does not match pattern.");
+
+    return { project_id, database_id, document_path };
+  }
+
+  /**
+   * Get Project ID
+   */
+  get project_id() {
+    return this.parse().project_id;
+  }
+
+  /**
+   * Get Database ID
+   * Ex: `(default)`
+   */
+  get database_id() {
+    return this.parse().database_id;
+  }
+
+  /**
+   * Get document ID
+   */
+  get id(): string {
+    const path = this.parse().document_path;
+    const parts = path.split("/");
+    const docId = parts[parts.length - 1];
+    return docId
+  }
+
+  /**
+   * Get the collection ID
+   */
+  get collectionPath(): string {
+    const path = this.parse().document_path;
+    const parts = path.split("/");
+    const collectionPath = parts.slice(0, parts.length - 1).join("/");
+    return collectionPath
+  }
+  
+  /**
+   * Get document path
+   */
+  get path(): string {
+    return this.parse().document_path;
+  }
+}
+
 /**
  * A geo point value representing a point on the surface of Earth.
  */
-export type FirestoreLiteralGeoPointValue = {
+export class LiteralGeoPointValue {
   geoPointValue: {
     /**
      * The latitude in degrees. It must be in the range [-90.0, +90.0].
@@ -27,8 +106,11 @@ export type FirestoreLiteralGeoPointValue = {
      * The longitude in degrees. It must be in the range [-180.0, +180.0].
      */
     longitude: number
-  } 
-};
+  }
+  constructor(options: Pick<LiteralGeoPointValue, "geoPointValue">) {
+    this.geoPointValue = options.geoPointValue;
+  }
+}
 
 /**
  * Firestoreの値型定義
@@ -41,8 +123,8 @@ export type FirestoreFieldValue =
   | { booleanValue: boolean }
   | { nullValue: null }
   | { timestampValue: string }
-  | FirestoreLiteralGeoPointValue
-  | FirestoreLiteralDocumentReference
+  | Pick<LiteralGeoPointValue, 'geoPointValue'>
+  | Pick<LiteralDocumentReference, 'referenceValue'>
   | { mapValue: { fields: Record<string, FirestoreFieldValue> } }
   | { arrayValue: { values: FirestoreFieldValue[] } };
 

--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -87,11 +87,9 @@ export function convertFromFirestoreValue(
       }),
       {}
     );
-  } else if (
-    "arrayValue" in firestoreValue &&
-    firestoreValue.arrayValue.values
-  ) {
-    return firestoreValue.arrayValue.values.map(convertFromFirestoreValue);
+  } else if ("arrayValue" in firestoreValue) {
+    // The `values` field can be undefined, meaning that this is an empty array
+    return (firestoreValue.arrayValue.values ?? []).map(convertFromFirestoreValue);
   }
 
   return null;


### PR DESCRIPTION
Hello,

Thank you for publishing this package. I originally tried to use Google's [@googleapis/firestore](https://github.com/googleapis/google-api-nodejs-client/tree/main/src/apis/firestore) package but found it very painful! It was very different from what I was used to.

I've added support for Firestore Document References and GeoPoints to be decodable and encodable by this package.

The source of my findings come from the official Google REST API: https://github.com/googleapis/google-api-nodejs-client/blob/5870dfe31f4885eebc82c19f7471c50403308f26/src/apis/firestore/v1.ts#L2246

To accomplish this, 2 new classes have been added. Classes were chosen because it makes detection at runtime very easy and requires users to opt-into using this.
- `LiteralDocumentReference`
- `LiteralGeoPointValue`

When converting from Firestore to JS, instances of the class are created which make identifying them simple from client libraries:

https://github.com/nabettu/firebase-rest-firestore/blob/28ff73c2cb391963160e621fffceb6cee7b63afc/src/utils/converter.ts#L76-L82

When converting to Firestore from JS, values must be actual instances of the `LiteralDocumentReference` and `LiteralGeoPointValue` classes to make using the feature opt-in and require explicit use:

https://github.com/nabettu/firebase-rest-firestore/blob/28ff73c2cb391963160e621fffceb6cee7b63afc/src/utils/converter.ts#L21-L27

The classes intentionally have the exact same properties as the underlying Firestore property to keep things simple and predictable. The `LiteralDocumentReference` class also has helpful "getters" that make turning it into a live `DocumentReference` class much easier. To make these getters more reliable and easier to understand, [URLPattern](https://developer.mozilla.org/en-US/docs/Web/API/URLPattern) is used. The package.json specifies Node.js v20 and v18 support, which doesn't support URLPattern. [urlpattern-polyfill](https://www.npmjs.com/package/urlpattern-polyfill) package is used to accommodate.

https://github.com/nabettu/firebase-rest-firestore/blob/28ff73c2cb391963160e621fffceb6cee7b63afc/src/types.ts#L17-L113