### PR TITLE
refactor: encode DocumentReference via public API and drop urlpattern-polyfill dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "jose": "^4.14.4",
-        "urlpattern-polyfill": "^10.1.0"
+        "jose": "^4.14.4"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
@@ -8011,12 +8010,6 @@
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
-    },
-    "node_modules/urlpattern-polyfill": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
-      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
-      "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "emulator:start": "cd test/emulator && firebase emulators:start -P demo-test-project",
     "emulator:stop": "npx kill-port -y 4089 8089 9089",
     "test": "vitest",
-    "test:unit": "vitest run test/converter.test.ts",
+    "test:unit": "vitest run test/converter.test.ts test/references.test.ts",
     "test:emulator": "bash test/scripts/test-with-emulator.sh"
   },
   "keywords": [
@@ -39,8 +39,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "jose": "^4.14.4",
-    "urlpattern-polyfill": "^10.1.0"
+    "jose": "^4.14.4"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",

--- a/src/client.ts
+++ b/src/client.ts
@@ -121,6 +121,16 @@ export class FirestoreClient {
   }
 
   /**
+   * Build the fully-qualified Firestore reference value for a document path,
+   * e.g. `projects/{projectId}/databases/{databaseId}/documents/{path}`.
+   * Used to encode a DocumentReference without exposing internal path helpers.
+   * @param documentPath Document path (ex: "users/uid/posts/postId")
+   */
+  getReferenceValue(documentPath: string): string {
+    return this.pathUtil.getParentReference(documentPath);
+  }
+
+  /**
    * Get collection reference
    * @param path Collection path
    * @returns CollectionReference instance
@@ -872,6 +882,14 @@ export class DocumentReference {
    */
   get path(): string {
     return `${this.collectionPath}/${this.docId}`;
+  }
+
+  /**
+   * Fully-qualified Firestore reference value for this document, e.g.
+   * `projects/{projectId}/databases/{databaseId}/documents/{path}`.
+   */
+  get referenceValue(): string {
+    return this.client.getReferenceValue(this.path);
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
-import { URLPattern } from "urlpattern-polyfill"
-
 /**
  * Firestoreクライアントの設定インターフェース
  */
@@ -25,28 +23,22 @@ export class LiteralDocumentReference {
   }
 
   /**
-   * The pattern for globally unique Firestore Document Reference paths
+   * Globally unique Firestore document reference paths look like:
+   *   projects/{project_id}/databases/{database_id}/documents/{document_path}
+   * The database id (e.g. `(default)`) never contains a slash, while the
+   * document path may contain many. A single anchored regex parses this
+   * without pulling in a URLPattern polyfill.
    */
-  private static pattern = new URLPattern({ pathname: `/projects/:project_id/databases/:database_id/documents/:document_path*`});
+  private static readonly pattern =
+    /^projects\/([^/]+)\/databases\/([^/]+)\/documents\/(.+)$/;
 
-  /**
-   * Parse using URLPattern, which is a relatively new addition to the standard.
-   * See: https://urlpattern.spec.whatwg.org/#dom-urlpattern-protocol
-   * Added in Node.js v23: https://nodejs.org/api/url.html#class-urlpattern
-   * Baseline 2025 in browsers: https://developer.mozilla.org/en-US/docs/Web/API/URLPattern/protocol
-   * @returns 
-   */
   private parse() {
-    const result = LiteralDocumentReference.pattern.exec(`https://hostname/${this.referenceValue}`);
-    if (!result) throw new Error("Invalid document path. Path does not match pattern.");
+    const match = LiteralDocumentReference.pattern.exec(this.referenceValue);
+    if (!match) {
+      throw new Error("Invalid document path. Path does not match pattern.");
+    }
 
-    const project_id = result.pathname.groups["project_id"];
-    if (!project_id) throw new Error("Invalid document path. Path does not match pattern.");
-    const database_id = result.pathname.groups["database_id"];
-    if (!database_id) throw new Error("Invalid document path. Path does not match pattern.");
-    const document_path = result.pathname.groups["document_path"];
-    if (!document_path) throw new Error("Invalid document path. Path does not match pattern.");
-
+    const [, project_id, database_id, document_path] = match;
     return { project_id, database_id, document_path };
   }
 

--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -14,12 +14,10 @@ import { getDocumentId } from "./path";
  * @returns Firestore形式の値
  */
 export function convertToFirestoreValue(value: any): FirestoreFieldValue {
-  // store in temporary variable to enable TypeScript to be more thorough
-  let unknown: unknown = value;
   if (value instanceof Date) {
     return { timestampValue: value.toISOString() };
   } else if (value instanceof DocumentReference) {
-    return { referenceValue: value["client"]["pathUtil"].getParentReference(value.path) };
+    return { referenceValue: value.referenceValue };
   } else if (value instanceof LiteralDocumentReference) {
     return { referenceValue: value.referenceValue }
   } else if (value instanceof LiteralGeoPointValue) {

--- a/test/references.test.ts
+++ b/test/references.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  convertToFirestoreValue,
+  convertFromFirestoreValue,
+} from "../src/utils/converter";
+import { createFirestoreClient } from "../src/client";
+import { LiteralDocumentReference, LiteralGeoPointValue } from "../src/types";
+
+/**
+ * Tests for Firestore document-reference / geo-point value handling.
+ *
+ * These are dependency-free: building a client and converting values performs
+ * no network I/O, so they run without the emulator or credentials.
+ *
+ * They drive two follow-ups taken over from PR #7:
+ *  1. Encode a `DocumentReference` through a public API instead of reaching
+ *     into private members (`client["pathUtil"]`).
+ *  2. Parse `LiteralDocumentReference` without the `urlpattern-polyfill`
+ *     dependency.
+ */
+
+function makeClient(databaseId?: string) {
+  return createFirestoreClient({
+    projectId: "test-project",
+    privateKey: "",
+    clientEmail: "",
+    databaseId,
+  });
+}
+
+describe("DocumentReference -> referenceValue", () => {
+  it("exposes a public referenceValue for the default database", () => {
+    const ref = makeClient().doc("users/u1/posts/post1");
+    expect(ref.referenceValue).toBe(
+      "projects/test-project/databases/(default)/documents/users/u1/posts/post1"
+    );
+  });
+
+  it("honors a custom databaseId", () => {
+    const ref = makeClient("my-db").doc("users/u1");
+    expect(ref.referenceValue).toBe(
+      "projects/test-project/databases/my-db/documents/users/u1"
+    );
+  });
+
+  it("encodes a DocumentReference via the public API (no private access)", () => {
+    const ref = makeClient().doc("a/b");
+    expect(convertToFirestoreValue(ref)).toEqual({
+      referenceValue: "projects/test-project/databases/(default)/documents/a/b",
+    });
+  });
+});
+
+describe("LiteralDocumentReference parsing (no urlpattern dependency)", () => {
+  const ref =
+    "projects/test-project/databases/(default)/documents/users/u1/posts/post1";
+
+  it("parses all components of a nested document path", () => {
+    const ldr = new LiteralDocumentReference({ referenceValue: ref });
+    expect(ldr.project_id).toBe("test-project");
+    expect(ldr.database_id).toBe("(default)");
+    expect(ldr.id).toBe("post1");
+    expect(ldr.path).toBe("users/u1/posts/post1");
+    expect(ldr.collectionPath).toBe("users/u1/posts");
+  });
+
+  it("parses a top-level document path", () => {
+    const ldr = new LiteralDocumentReference({
+      referenceValue: "projects/p/databases/(default)/documents/users/u1",
+    });
+    expect(ldr.id).toBe("u1");
+    expect(ldr.path).toBe("users/u1");
+    expect(ldr.collectionPath).toBe("users");
+  });
+
+  it("throws on an invalid reference", () => {
+    expect(
+      () =>
+        new LiteralDocumentReference({ referenceValue: "not-a-ref" }).project_id
+    ).toThrow(/Invalid document path/);
+  });
+
+  it("round-trips through convertToFirestoreValue", () => {
+    expect(
+      convertToFirestoreValue(
+        new LiteralDocumentReference({ referenceValue: ref })
+      )
+    ).toEqual({ referenceValue: ref });
+  });
+
+  it("decodes referenceValue into a LiteralDocumentReference", () => {
+    const v = convertFromFirestoreValue({ referenceValue: ref } as any);
+    expect(v).toBeInstanceOf(LiteralDocumentReference);
+    expect(v.id).toBe("post1");
+    expect(v.path).toBe("users/u1/posts/post1");
+  });
+});
+
+describe("LiteralGeoPointValue", () => {
+  it("encodes to geoPointValue", () => {
+    expect(
+      convertToFirestoreValue(
+        new LiteralGeoPointValue({
+          geoPointValue: { latitude: 35.6, longitude: 139.7 },
+        })
+      )
+    ).toEqual({ geoPointValue: { latitude: 35.6, longitude: 139.7 } });
+  });
+
+  it("decodes geoPointValue into a LiteralGeoPointValue", () => {
+    const v = convertFromFirestoreValue({
+      geoPointValue: { latitude: 1, longitude: 2 },
+    } as any);
+    expect(v).toBeInstanceOf(LiteralGeoPointValue);
+    expect(v.geoPointValue).toEqual({ latitude: 1, longitude: 2 });
+  });
+});


### PR DESCRIPTION
Follow-up to #7 (merged) — taking over the two review notes on our side, implemented with TDD.

## What & why

1. **Encode `DocumentReference` through a public API.** The merged code reached into private members via `value["client"]["pathUtil"].getParentReference(...)`, which is brittle against refactors. Added:
   - `FirestoreClient#getReferenceValue(documentPath)` (public)
   - `DocumentReference#referenceValue` getter (public, mirrors `LiteralDocumentReference.referenceValue`)
   - The converter now does `{ referenceValue: value.referenceValue }`.

2. **Drop the `urlpattern-polyfill` dependency.** `LiteralDocumentReference` now parses with a single anchored regex (`^projects/.../databases/.../documents/(.+)$`). This removes a runtime dependency that was added with an unpinned `^` range — aligning with the repo's exact-pinning / supply-chain stance — while keeping all the getters (`id` / `path` / `collectionPath` / `project_id` / `database_id`) identical.

3. Removed a dead temporary variable in `convertToFirestoreValue`.

## Tests (TDD)

Added `test/references.test.ts` (dependency-free, no emulator/credentials):
- `DocumentReference.referenceValue` resolves for default and custom `databaseId`, and round-trips through `convertToFirestoreValue`
- `LiteralDocumentReference` parses nested & top-level paths, throws on invalid input, and decode/encode round-trips
- `LiteralGeoPointValue` encode/decode

Wired into `npm run test:unit` (the new `pull_request` CI). `npm run build` (type-check) passes; no public behavior changes — `.referenceValue` output is byte-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
