### PR TITLE
feat: add FieldValue.serverTimestamp() support (closes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,43 @@ Parameters:
 
 Returns: The added document with auto-generated ID.
 
+### FieldValue
+
+Sentinels for special write behaviors, mirroring the native Firebase SDK.
+
+#### FieldValue.serverTimestamp()
+
+Sets the field to the server's request timestamp at write time (rather than an
+unreliable client clock). Works with `add`, `update`, `set`, and `createWithId`,
+including nested fields. The returned document contains the resolved `Date`.
+
+```typescript
+import { createFirestoreClient, FieldValue } from "firebase-rest-firestore";
+
+const client = createFirestoreClient(config);
+
+// On create (auto-generated ID)
+const post = await client.add("posts", {
+  title: "Hello",
+  createdAt: FieldValue.serverTimestamp(),
+});
+console.log(post.createdAt); // Date, set by the server
+
+// On update
+await client.update("posts", post.id, {
+  updatedAt: FieldValue.serverTimestamp(),
+});
+
+// Nested fields are supported too
+await client.collection("posts").doc(post.id).set({
+  meta: { touchedAt: FieldValue.serverTimestamp() },
+});
+```
+
+> Writes containing a `FieldValue` are sent through the Firestore `commit`
+> endpoint so the transform is applied server-side. A `FieldValue` cannot be
+> used inside an array.
+
 ## Error Handling
 
 Firebase REST Firestore throws exceptions with appropriate error messages when API requests fail. Here's an example of error handling:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "emulator:start": "cd test/emulator && firebase emulators:start -P demo-test-project",
     "emulator:stop": "npx kill-port -y 4089 8089 9089",
     "test": "vitest",
-    "test:unit": "vitest run test/converter.test.ts test/references.test.ts",
+    "test:unit": "vitest run test/converter.test.ts test/references.test.ts test/field-value.test.ts",
     "test:emulator": "bash test/scripts/test-with-emulator.sh"
   },
   "keywords": [

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,13 +1,29 @@
 import { FirestoreConfig, FirestoreResponse, QueryOptions } from "./types";
 import { getFirestoreToken } from "./utils/auth";
 import {
+  buildCommitWrite,
   convertFromFirestoreDocument,
   convertToFirestoreDocument,
   convertToFirestoreValue,
+  extractFieldTransforms,
 } from "./utils/converter";
+import { FieldTransform } from "./types";
 import { getFirestoreBasePath } from "./utils/path";
 import { formatPrivateKey } from "./utils/config";
 import { FirestorePath, createFirestorePath } from "./utils/path";
+
+/**
+ * Generate a random 20-character document ID (same alphabet as the Firebase SDKs).
+ */
+function generateAutoId(): string {
+  const chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let id = "";
+  for (let i = 0; i < 20; i++) {
+    id += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return id;
+}
 
 /**
  * Firestore client class
@@ -131,6 +147,90 @@ export class FirestoreClient {
   }
 
   /**
+   * Apply a single write through the `documents:commit` endpoint. This is the
+   * only REST path that supports field transforms (e.g. server timestamps).
+   * @param collectionName Collection path
+   * @param documentId Document ID
+   * @param fields Already-converted Firestore field values
+   * @param transforms Field transforms to apply after the update
+   * @param currentDocument Optional precondition (e.g. `{ exists: false }`)
+   * @private
+   */
+  private async commit(
+    collectionName: string,
+    documentId: string,
+    fields: Record<string, any>,
+    transforms: FieldTransform[],
+    currentDocument?: { exists?: boolean; updateTime?: string }
+  ): Promise<void> {
+    const documentName = this.pathUtil.getParentReference(
+      `${collectionName}/${documentId}`
+    );
+    const write = buildCommitWrite(
+      documentName,
+      fields,
+      transforms,
+      currentDocument
+    );
+    const url = `${this.pathUtil.getBasePath()}:commit`;
+
+    if (this.debug) {
+      console.log(`Committing write to: ${url}`, JSON.stringify(write));
+    }
+
+    const headers = await this.prepareHeaders();
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ writes: [write] }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      if (this.debug) {
+        console.error(`Error response: ${errorText}`);
+      }
+      const error = new Error(
+        `Firestore API error: ${
+          response.statusText || response.status
+        } - ${errorText}`
+      ) as Error & { status?: number; alreadyExists?: boolean };
+      error.status = response.status;
+      error.alreadyExists =
+        response.status === 409 || /ALREADY_EXISTS/.test(errorText);
+      throw error;
+    }
+  }
+
+  /**
+   * Commit a write and read the document back, so the resolved transform
+   * values (e.g. the server timestamp) are returned to the caller.
+   * @private
+   */
+  private async commitAndRead(
+    collectionName: string,
+    documentId: string,
+    fields: Record<string, any>,
+    transforms: FieldTransform[],
+    currentDocument?: { exists?: boolean; updateTime?: string }
+  ): Promise<Record<string, any> & { id: string }> {
+    await this.commit(
+      collectionName,
+      documentId,
+      fields,
+      transforms,
+      currentDocument
+    );
+    const saved = await this.get(collectionName, documentId);
+    if (!saved) {
+      throw new Error(
+        `Document ${collectionName}/${documentId} could not be read back after commit`
+      );
+    }
+    return saved;
+  }
+
+  /**
    * Get collection reference
    * @param path Collection path
    * @returns CollectionReference instance
@@ -183,6 +283,13 @@ export class FirestoreClient {
       console.log(`Adding document to collection: ${collectionName}`, data);
     }
 
+    // When the data contains field transforms (e.g. serverTimestamp), the
+    // create must go through the commit endpoint with a client-generated ID.
+    const { fields: plainData, transforms } = extractFieldTransforms(data);
+    if (transforms.length > 0) {
+      return this.addWithTransforms(collectionName, plainData, transforms);
+    }
+
     const url = this.pathUtil.getCollectionPath(collectionName);
     const firestoreData = convertToFirestoreDocument(data);
 
@@ -216,6 +323,45 @@ export class FirestoreClient {
 
     const result = (await response.json()) as FirestoreResponse;
     return convertFromFirestoreDocument(result);
+  }
+
+  /**
+   * Create a document that contains field transforms (e.g. serverTimestamp)
+   * with an auto-generated ID. Uses the commit endpoint with an
+   * `exists: false` precondition and retries on the (astronomically unlikely)
+   * ID collision, mirroring the uniqueness of server-generated IDs.
+   * @private
+   */
+  private async addWithTransforms(
+    collectionName: string,
+    plainData: Record<string, any>,
+    transforms: FieldTransform[]
+  ) {
+    const fields = convertToFirestoreDocument(plainData).fields;
+    const maxAttempts = 5;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const documentId = generateAutoId();
+      try {
+        return await this.commitAndRead(
+          collectionName,
+          documentId,
+          fields,
+          transforms,
+          { exists: false }
+        );
+      } catch (error) {
+        const collided = (error as { alreadyExists?: boolean })?.alreadyExists;
+        if (collided && attempt < maxAttempts - 1) {
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    throw new Error(
+      "Failed to generate a unique document ID after multiple attempts"
+    );
   }
 
   /**
@@ -360,6 +506,14 @@ export class FirestoreClient {
         // 通常のマージ
         data = { ...existingDoc, ...data };
       }
+    }
+
+    // Route writes that contain field transforms (e.g. serverTimestamp)
+    // through the commit endpoint; the merged document is sent as the update.
+    const { fields: plainData, transforms } = extractFieldTransforms(data);
+    if (transforms.length > 0) {
+      const fields = convertToFirestoreDocument(plainData).fields;
+      return this.commitAndRead(collectionName, documentId, fields, transforms);
     }
 
     const firestoreData = convertToFirestoreDocument(data);
@@ -623,6 +777,14 @@ export class FirestoreClient {
     // 操作前に設定をチェック
     this.checkConfig();
 
+    // Route writes that contain field transforms (e.g. serverTimestamp)
+    // through the commit endpoint (which creates the document if absent).
+    const { fields: plainData, transforms } = extractFieldTransforms(data);
+    if (transforms.length > 0) {
+      const fields = convertToFirestoreDocument(plainData).fields;
+      return this.commitAndRead(collectionName, documentId, fields, transforms);
+    }
+
     const url = `${getFirestoreBasePath(
       this.config.projectId,
       this.config.databaseId,
@@ -845,14 +1007,7 @@ export class CollectionReference {
    * @returns Random ID
    */
   private _generateId(): string {
-    // Generate 20-character random ID
-    const chars =
-      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-    let id = "";
-    for (let i = 0; i < 20; i++) {
-      id += chars.charAt(Math.floor(Math.random() * chars.length));
-    }
-    return id;
+    return generateAutoId();
   }
 }
 

--- a/src/field-value.ts
+++ b/src/field-value.ts
@@ -1,0 +1,27 @@
+/**
+ * Sentinel values for special write behaviors, mirroring the native Firebase
+ * SDK's `FieldValue`. Currently only `serverTimestamp()` is supported.
+ *
+ * A `FieldValue` is not a real field value: when used as a field in a write it
+ * is translated into a Firestore field transform (applied server-side) rather
+ * than serialized as data. Using one anywhere else (e.g. inside an array) is an
+ * error.
+ */
+export class FieldValue {
+  private constructor(readonly methodName: "serverTimestamp") {}
+
+  /**
+   * Returns a sentinel that sets the field to the server's request timestamp at
+   * write time, e.g. `client.add("posts", { createdAt: FieldValue.serverTimestamp() })`.
+   */
+  static serverTimestamp(): FieldValue {
+    return new FieldValue("serverTimestamp");
+  }
+
+  /**
+   * Whether this sentinel represents the same transform as another.
+   */
+  isEqual(other: FieldValue): boolean {
+    return other instanceof FieldValue && other.methodName === this.methodName;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,9 @@ import {
   WriteResult,
 } from "./client";
 
+// FieldValue センチネルのエクスポート
+export { FieldValue } from "./field-value";
+
 // ユーティリティ関数のエクスポート
 export { getFirestoreToken } from "./utils/auth";
 export {

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,24 @@ export type FirestoreFieldValue =
   | { arrayValue: { values: FirestoreFieldValue[] } };
 
 /**
+ * A Firestore field transform applied server-side during a commit write.
+ * See: https://firebase.google.com/docs/firestore/reference/rest/v1/Write#FieldTransform
+ */
+export interface FieldTransform {
+  fieldPath: string;
+  setToServerValue: "REQUEST_TIME";
+}
+
+/**
+ * A single write in a `documents:commit` request.
+ */
+export interface CommitWrite {
+  update: { name: string; fields: Record<string, FirestoreFieldValue> };
+  updateTransforms?: FieldTransform[];
+  currentDocument?: { exists?: boolean; updateTime?: string };
+}
+
+/**
  * Firestoreドキュメント型
  */
 export interface FirestoreDocument {

--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -1,5 +1,8 @@
 import { DocumentReference } from "../client"
+import { FieldValue } from "../field-value";
 import {
+  CommitWrite,
+  FieldTransform,
   FirestoreDocument,
   FirestoreFieldValue,
   FirestoreResponse,
@@ -14,6 +17,14 @@ import { getDocumentId } from "./path";
  * @returns Firestore形式の値
  */
 export function convertToFirestoreValue(value: any): FirestoreFieldValue {
+  if (value instanceof FieldValue) {
+    // Sentinels (e.g. serverTimestamp) must be extracted into field transforms
+    // before conversion. Reaching here means one was used where Firestore
+    // cannot express a transform (such as inside an array).
+    throw new Error(
+      "FieldValue (e.g. serverTimestamp()) can only be used as a top-level or nested document field value, not inside an array."
+    );
+  }
   if (value instanceof Date) {
     return { timestampValue: value.toISOString() };
   } else if (value instanceof DocumentReference) {
@@ -110,6 +121,85 @@ export function convertToFirestoreDocument(
       {}
     ),
   };
+}
+
+/**
+ * Whether a value is a plain JS object (`{}` / `Object.create(null)`), as
+ * opposed to a class instance such as `Date`, `DocumentReference`,
+ * `LiteralGeoPointValue`, `LiteralDocumentReference`, `FieldValue`, or an array.
+ * Only plain objects are recursed into when extracting field transforms.
+ */
+function isPlainObject(value: any): boolean {
+  if (value === null || typeof value !== "object") return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Split write data into plain field values and Firestore field transforms.
+ *
+ * `FieldValue` sentinels (e.g. `serverTimestamp()`) are pulled out into
+ * transforms keyed by their (dot-separated) field path; everything else is
+ * left untouched in `fields`. Recursion only descends into plain objects, so
+ * class instances (Date / references / geo points) are treated as leaves.
+ *
+ * @param data Write data (JS values, may contain FieldValue sentinels)
+ * @param prefix Field-path prefix used while recursing (internal)
+ */
+export function extractFieldTransforms(
+  data: Record<string, any>,
+  prefix: string = ""
+): { fields: Record<string, any>; transforms: FieldTransform[] } {
+  const fields: Record<string, any> = {};
+  const transforms: FieldTransform[] = [];
+
+  for (const [key, value] of Object.entries(data)) {
+    const fieldPath = prefix ? `${prefix}.${key}` : key;
+
+    if (value instanceof FieldValue) {
+      if (value.methodName === "serverTimestamp") {
+        transforms.push({ fieldPath, setToServerValue: "REQUEST_TIME" });
+      } else {
+        throw new Error(`Unsupported FieldValue: ${value.methodName}`);
+      }
+    } else if (isPlainObject(value)) {
+      const nested = extractFieldTransforms(value, fieldPath);
+      fields[key] = nested.fields;
+      transforms.push(...nested.transforms);
+    } else {
+      fields[key] = value;
+    }
+  }
+
+  return { fields, transforms };
+}
+
+/**
+ * Build a single `documents:commit` write that updates a document and applies
+ * field transforms. `updateTransforms` / `currentDocument` are only included
+ * when relevant.
+ *
+ * @param documentName Full resource name (projects/.../documents/<path>)
+ * @param fields Already-converted Firestore field values
+ * @param transforms Field transforms to apply after the update
+ * @param currentDocument Optional precondition (e.g. `{ exists: false }`)
+ */
+export function buildCommitWrite(
+  documentName: string,
+  fields: Record<string, FirestoreFieldValue>,
+  transforms: FieldTransform[],
+  currentDocument?: { exists?: boolean; updateTime?: string }
+): CommitWrite {
+  const write: CommitWrite = {
+    update: { name: documentName, fields },
+  };
+  if (transforms.length > 0) {
+    write.updateTransforms = transforms;
+  }
+  if (currentDocument) {
+    write.currentDocument = currentDocument;
+  }
+  return write;
 }
 
 /**

--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -136,15 +136,31 @@ function isPlainObject(value: any): boolean {
 }
 
 /**
+ * Escape a single field name for use in a Firestore field path. Simple names
+ * (`[A-Za-z_][A-Za-z0-9_]*`) are used as-is; anything else (dashes, dots,
+ * leading digits, spaces, ...) is wrapped in backticks with `\` and `` ` ``
+ * escaped, so a literal dot in a key is treated as part of the name rather than
+ * a path separator.
+ * See: https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents#Document
+ */
+function escapeFieldPathSegment(segment: string): string {
+  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(segment)) {
+    return segment;
+  }
+  return "`" + segment.replace(/\\/g, "\\\\").replace(/`/g, "\\`") + "`";
+}
+
+/**
  * Split write data into plain field values and Firestore field transforms.
  *
  * `FieldValue` sentinels (e.g. `serverTimestamp()`) are pulled out into
- * transforms keyed by their (dot-separated) field path; everything else is
- * left untouched in `fields`. Recursion only descends into plain objects, so
- * class instances (Date / references / geo points) are treated as leaves.
+ * transforms keyed by their (escaped, dot-separated) field path; everything
+ * else is left untouched in `fields`. Recursion only descends into plain
+ * objects, so class instances (Date / references / geo points) are treated as
+ * leaves.
  *
  * @param data Write data (JS values, may contain FieldValue sentinels)
- * @param prefix Field-path prefix used while recursing (internal)
+ * @param prefix Field-path prefix used while recursing (internal, pre-escaped)
  */
 export function extractFieldTransforms(
   data: Record<string, any>,
@@ -154,7 +170,8 @@ export function extractFieldTransforms(
   const transforms: FieldTransform[] = [];
 
   for (const [key, value] of Object.entries(data)) {
-    const fieldPath = prefix ? `${prefix}.${key}` : key;
+    const escapedKey = escapeFieldPathSegment(key);
+    const fieldPath = prefix ? `${prefix}.${escapedKey}` : escapedKey;
 
     if (value instanceof FieldValue) {
       if (value.methodName === "serverTimestamp") {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -4,6 +4,7 @@ import {
   createFirestoreClient,
   DocumentReference,
 } from "../src/client";
+import { FieldValue } from "../src/field-value";
 import { loadConfig, getTestCollectionName } from "./helpers";
 
 /**
@@ -667,5 +668,44 @@ describe("Firebase Rest Firestore", () => {
     // Verify the parent collection is correctly identified
     const collectionRef = docRef.parent;
     expect(collectionRef.path).toBe("users/user123/posts");
+  });
+
+  // Server timestamp test (FieldValue.serverTimestamp)
+  it("Should populate fields with the server timestamp via FieldValue.serverTimestamp()", async () => {
+    const before = Date.now();
+
+    // serverTimestamp on add() (auto-generated ID via commit)
+    const created = await client.add(testCollection, {
+      name: "ts",
+      createdAt: FieldValue.serverTimestamp(),
+    });
+    createdIds.push({ collection: testCollection, id: created.id });
+
+    expect(created.name).toBe("ts");
+    expect(created.createdAt).toBeInstanceOf(Date);
+    const createdMs = (created.createdAt as Date).getTime();
+    expect(createdMs).toBeGreaterThanOrEqual(before - 1000);
+    expect(createdMs).toBeLessThanOrEqual(Date.now() + 1000);
+
+    // serverTimestamp on update(); existing fields preserved
+    const updated = await client.update(testCollection, created.id, {
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    expect(updated.updatedAt).toBeInstanceOf(Date);
+    expect(updated.name).toBe("ts");
+    expect(updated.createdAt).toBeInstanceOf(Date);
+
+    // nested serverTimestamp via DocumentReference.set on a new document
+    const ref = client.collection(testCollection).doc();
+    createdIds.push({ collection: testCollection, id: ref.id });
+    await ref.set({
+      label: "x",
+      meta: { touchedAt: FieldValue.serverTimestamp() },
+    });
+
+    const snap = await ref.get();
+    expect(snap.exists).toBe(true);
+    expect(snap.data()?.label).toBe("x");
+    expect(snap.data()?.meta?.touchedAt).toBeInstanceOf(Date);
   });
 });

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -674,15 +674,18 @@ describe("Firebase Rest Firestore", () => {
   it("Should populate fields with the server timestamp via FieldValue.serverTimestamp()", async () => {
     const before = Date.now();
 
-    // serverTimestamp on add() (auto-generated ID via commit)
+    // serverTimestamp on add() (auto-generated ID via commit); a non-simple
+    // field name ("created-at") exercises field-path backtick escaping.
     const created = await client.add(testCollection, {
       name: "ts",
       createdAt: FieldValue.serverTimestamp(),
+      "created-at": FieldValue.serverTimestamp(),
     });
     createdIds.push({ collection: testCollection, id: created.id });
 
     expect(created.name).toBe("ts");
     expect(created.createdAt).toBeInstanceOf(Date);
+    expect(created["created-at"]).toBeInstanceOf(Date);
     const createdMs = (created.createdAt as Date).getTime();
     expect(createdMs).toBeGreaterThanOrEqual(before - 1000);
     expect(createdMs).toBeLessThanOrEqual(Date.now() + 1000);

--- a/test/field-value.test.ts
+++ b/test/field-value.test.ts
@@ -84,6 +84,24 @@ describe("extractFieldTransforms", () => {
     expect(fields).toEqual(data);
   });
 
+  it("backtick-escapes non-simple field names", () => {
+    const { transforms } = extractFieldTransforms({
+      "created-at": FieldValue.serverTimestamp(),
+    });
+    expect(transforms).toEqual([
+      { fieldPath: "`created-at`", setToServerValue: "REQUEST_TIME" },
+    ]);
+  });
+
+  it("escapes a literal dot in a field name (not treated as a path separator)", () => {
+    const { transforms } = extractFieldTransforms({
+      meta: { "x.y": FieldValue.serverTimestamp() },
+    });
+    expect(transforms).toEqual([
+      { fieldPath: "meta.`x.y`", setToServerValue: "REQUEST_TIME" },
+    ]);
+  });
+
   it("treats Date / DocumentReference / LiteralGeoPointValue as leaves (no recursion)", () => {
     const ref = makeClient().doc("a/b");
     const geo = new LiteralGeoPointValue({

--- a/test/field-value.test.ts
+++ b/test/field-value.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { FieldValue } from "../src/field-value";
+import {
+  extractFieldTransforms,
+  convertToFirestoreValue,
+  buildCommitWrite,
+} from "../src/utils/converter";
+import { createFirestoreClient } from "../src/client";
+import { LiteralGeoPointValue } from "../src/types";
+
+/**
+ * Dependency-free unit tests for FieldValue.serverTimestamp() support (issue #5).
+ * These exercise the pure pieces — the sentinel, transform extraction, the
+ * conversion safety-net, and the commit-write body shape — with no network I/O.
+ * The actual :commit round-trip is covered by the emulator integration test.
+ */
+
+function makeClient() {
+  return createFirestoreClient({
+    projectId: "p",
+    privateKey: "",
+    clientEmail: "",
+  });
+}
+
+describe("FieldValue", () => {
+  it("serverTimestamp() returns a FieldValue sentinel", () => {
+    const fv = FieldValue.serverTimestamp();
+    expect(fv).toBeInstanceOf(FieldValue);
+    expect(fv.methodName).toBe("serverTimestamp");
+  });
+
+  it("isEqual compares by method", () => {
+    expect(
+      FieldValue.serverTimestamp().isEqual(FieldValue.serverTimestamp())
+    ).toBe(true);
+  });
+});
+
+describe("extractFieldTransforms", () => {
+  it("pulls a top-level serverTimestamp into transforms", () => {
+    const { fields, transforms } = extractFieldTransforms({
+      name: "a",
+      createdAt: FieldValue.serverTimestamp(),
+    });
+    expect(fields).toEqual({ name: "a" });
+    expect(transforms).toEqual([
+      { fieldPath: "createdAt", setToServerValue: "REQUEST_TIME" },
+    ]);
+  });
+
+  it("produces a dotted fieldPath for nested sentinels and keeps the surrounding map", () => {
+    const { fields, transforms } = extractFieldTransforms({
+      meta: { v: 1, updatedAt: FieldValue.serverTimestamp() },
+    });
+    expect(fields).toEqual({ meta: { v: 1 } });
+    expect(transforms).toEqual([
+      { fieldPath: "meta.updatedAt", setToServerValue: "REQUEST_TIME" },
+    ]);
+  });
+
+  it("handles multiple sentinels at different depths", () => {
+    const { fields, transforms } = extractFieldTransforms({
+      a: FieldValue.serverTimestamp(),
+      b: { c: FieldValue.serverTimestamp() },
+    });
+    expect(fields).toEqual({ b: {} });
+    expect(transforms).toEqual([
+      { fieldPath: "a", setToServerValue: "REQUEST_TIME" },
+      { fieldPath: "b.c", setToServerValue: "REQUEST_TIME" },
+    ]);
+  });
+
+  it("returns empty transforms and untouched fields when there are no sentinels", () => {
+    const data = {
+      name: "x",
+      n: 2,
+      when: new Date("2026-01-01T00:00:00.000Z"),
+      tags: ["a"],
+      nested: { y: 1 },
+    };
+    const { fields, transforms } = extractFieldTransforms(data);
+    expect(transforms).toEqual([]);
+    expect(fields).toEqual(data);
+  });
+
+  it("treats Date / DocumentReference / LiteralGeoPointValue as leaves (no recursion)", () => {
+    const ref = makeClient().doc("a/b");
+    const geo = new LiteralGeoPointValue({
+      geoPointValue: { latitude: 1, longitude: 2 },
+    });
+    const date = new Date("2026-01-01T00:00:00.000Z");
+    const { fields, transforms } = extractFieldTransforms({ ref, geo, date });
+    expect(transforms).toEqual([]);
+    expect(fields.ref).toBe(ref);
+    expect(fields.geo).toBe(geo);
+    expect(fields.date).toBe(date);
+  });
+});
+
+describe("convertToFirestoreValue safety net", () => {
+  it("throws if a FieldValue reaches conversion directly", () => {
+    expect(() => convertToFirestoreValue(FieldValue.serverTimestamp())).toThrow(
+      /FieldValue/
+    );
+  });
+
+  it("throws if a FieldValue is nested inside an array", () => {
+    expect(() =>
+      convertToFirestoreValue([FieldValue.serverTimestamp()])
+    ).toThrow(/FieldValue/);
+  });
+});
+
+describe("buildCommitWrite", () => {
+  const name = "projects/p/databases/(default)/documents/c/d";
+
+  it("builds an update write with transforms", () => {
+    const write = buildCommitWrite(
+      name,
+      { name: { stringValue: "a" } },
+      [{ fieldPath: "createdAt", setToServerValue: "REQUEST_TIME" }]
+    );
+    expect(write).toEqual({
+      update: { name, fields: { name: { stringValue: "a" } } },
+      updateTransforms: [
+        { fieldPath: "createdAt", setToServerValue: "REQUEST_TIME" },
+      ],
+    });
+  });
+
+  it("includes the currentDocument precondition when provided", () => {
+    const write = buildCommitWrite(name, {}, [], { exists: false });
+    expect(write).toEqual({
+      update: { name, fields: {} },
+      currentDocument: { exists: false },
+    });
+  });
+
+  it("omits updateTransforms when there are none", () => {
+    const write = buildCommitWrite(name, { a: { integerValue: 1 } }, []);
+    expect(write).toEqual({
+      update: { name, fields: { a: { integerValue: 1 } } },
+    });
+  });
+});


### PR DESCRIPTION
Closes #5.

Adds `FieldValue.serverTimestamp()` (mirroring the native Firebase SDK) so writes can set fields to the server's request time instead of an unreliable client clock.

## Approach
Server timestamps require Firestore **field transforms**, which only the `documents:commit` endpoint accepts (`createDocument`/`patch` do not). Writes that contain a `FieldValue` sentinel are routed through `:commit`; **all other writes are byte-identical to before** (zero behavior change on the hot path).

- `FieldValue` sentinel (`src/field-value.ts`) with `static serverTimestamp()`.
- `extractFieldTransforms()` splits sentinels into `FieldTransform`s, recursing **only into plain objects** (Date / DocumentReference / Literal\* stay leaves); `buildCommitWrite()` builds the commit body.
- Field paths are **backtick-escaped** per Firestore field-path syntax (e.g. `created-at` → `` `created-at` ``; a literal dot in a key is not treated as a separator).
- `convertToFirestoreValue` throws if a sentinel reaches conversion (e.g. inside an array, which Firestore transforms cannot express).
- `FirestoreClient.commit()` / `commitAndRead()` wire `add` / `update` / `createWithId`. `add` uses a client-generated ID with an `exists: false` precondition and **retries on ID collision**. The document is read back so the resolved `Date` is returned.
- Exported `FieldValue`; documented in the README.

## Usage
```ts
import { createFirestoreClient, FieldValue } from "firebase-rest-firestore";
const post = await client.add("posts", { title: "Hi", createdAt: FieldValue.serverTimestamp() });
await client.update("posts", post.id, { updatedAt: FieldValue.serverTimestamp() });
```

## Tests
- Dependency-free unit tests (`test/field-value.test.ts`, wired into `npm run test:unit`): sentinel, extraction (nested, multiple, escaping, leaves), array-throw, commit-write shape — **45 unit tests pass**.
- Emulator integration test (`test/client.test.ts`): `add` / `update` / nested `set` + an escaped `created-at` field — **verified green against the Firestore emulator (10/10)**.
- `npm run build` (type-check) passes.

## Review
Designed plan-first and reviewed by codex (plan + implementation); the field-path escaping fix came from that review and codex's final verdict is LGTM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
