### PR TITLE
fix: use prepareHeaders() in createWithId so emulator writes work

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -793,13 +793,10 @@ export class FirestoreClient {
 
     const firestoreData = convertToFirestoreDocument(data);
 
-    const token = await this.getToken();
+    const headers = await this.prepareHeaders();
     const response = await fetch(url, {
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
+      headers,
       body: JSON.stringify(firestoreData),
     });
 


### PR DESCRIPTION
## Problem

`createWithId()` is the only `FirestoreClient` method that still attaches the auth header unconditionally:

```ts
const token = await this.getToken();
const response = await fetch(url, {
  method: "PATCH",
  headers: {
    "Content-Type": "application/json",
    Authorization: `Bearer ${token}`,
  },
  ...
```

Under the emulator, `getToken()` returns the literal string `"emulator-fake-token"`. The Firestore emulator can't parse that as a credential and rejects the write.

This is reachable from the public API: `DocumentReference.set()` dispatches to `createWithId()` whenever the target document doesn't already exist. So `doc(id).set(data)` against the emulator fails for every new document.

## Fix

Route through `prepareHeaders()`, which already omits `Authorization` when `config.useEmulator` is set.

Every sibling method — `commit`, `add`, `get`, `update`, `query` — already calls it, and `delete()` inlines the equivalent check. `createWithId()` looks like it was simply missed when `prepareHeaders()` landed in #3 (that PR's diff doesn't touch this method).

## Impact

No behavior change in production. With `useEmulator` false, `prepareHeaders()` returns the identical `Content-Type` + `Authorization` pair the method builds by hand.

## Verification

`npm run build` clean, `npm run test:unit` passes (45 tests). Verified against a real Firestore emulator downstream: `doc(id).set(data)` on a new document fails on 1.6.0 and succeeds with this change.